### PR TITLE
ci: update package install command

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install local, editable package
       run: |
         python -m pip install --upgrade pip wheel
-        python -m pip install -e .[docs]
+        python -m pip install -r docs_requirements.txt && python -m pip install -e .
 
     - name: Build Documentation
       run: make -C docs html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2
 
     - name: Install package
-      run: python -m pip install -e .[dev]
+      run: python -m pip install -r dev_requirements.txt && python -m pip install -e .
 
     - name: Lint with flake8
       shell: bash


### PR DESCRIPTION
interdependency and version constraints with psyneulink prevents local
installation of graph-scheduler with the editable command because the
local version is always going to be newer than the remote restricted
version