### PR TITLE
requirements: limit numpy to >=1.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy >=1.19.0
 pint
 toposort


### PR DESCRIPTION
failure on calling gcd on list comprehension.
see https://github.com/PrincetonUniversity/PsyNeuLink/pull/2583