### PR TITLE
requirements: docs: restrict sphinx <7

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
 m2r2
-sphinx
+sphinx <7
 sphinx-autodoc-typehints
 sphinx-rtd-theme


### PR DESCRIPTION
Fixes docs build error in python 3.8+:

```
Theme error:
An error happened in rendering the page Condition.
Reason: UndefinedError("'style' is undefined")
make: *** [Makefile:20: html] Error 2
```