### PR TITLE
utilities: add several graph-related functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       if: ${{ matrix.python-version == 3.9 }}
       run: python -m pip install coveragepy-lcov "coverage<7.0.0"
 
+    - name: Install Graphviz
+      uses: tlylt/install-graphviz@v1
+
     - name: Lint with flake8
       shell: bash
       run: |

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,5 @@
 psyneulink >=0.9.1.0
+pydot
 pytest
 pytest-benchmark
 pytest-cov

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
-networkx
 psyneulink >=0.9.1.0
 pytest
 pytest-benchmark

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+networkx
 numpy >=1.19.0
 pint
 toposort

--- a/src/graph_scheduler/utilities.py
+++ b/src/graph_scheduler/utilities.py
@@ -5,7 +5,7 @@ import weakref
 from typing import Dict, Hashable, Set
 
 
-__all__ = ['clone_graph']
+__all__ = ['clone_graph', 'disable_debug_logging', 'enable_debug_logging']
 
 
 logger = logging.getLogger(__name__)
@@ -104,3 +104,49 @@ def clone_graph(graph: typing_graph_dependency_dict) -> typing_graph_dependency_
             v = set([v])
         res[k] = v
     return res
+
+
+def enable_debug_logging():
+    """
+    Enables display of debugging logs using python logging module
+
+    Note: sets python root logger level to DEBUG
+    """
+    root_logger = logging.getLogger()
+    gs_logger = logging.getLogger(__package__)
+    gs_logger.propagate = False
+
+    if len(gs_logger.handlers) == 0:
+        gs_logging_formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
+        )
+        gs_debug_log_handler = logging.StreamHandler()
+        gs_debug_log_handler.setLevel(logging.DEBUG)
+        gs_debug_log_handler.setFormatter(gs_logging_formatter)
+        gs_logger.addHandler(gs_debug_log_handler)
+
+    new_level = logging.DEBUG
+    root_logger.setLevel(new_level)
+
+    logger.info(
+        f"Changing root logger level to {logging.getLevelName(new_level)}"
+    )
+    logger.debug('Debug mode on')
+
+
+def disable_debug_logging(level: int = logging.WARNING):
+    """
+    Disables display of debugging logs using python logging module
+
+    Args:
+        level (int, optional): Level to reset root logger to. Defaults
+            to logging.WARNING (root logger default).
+    """
+    root_logger = logging.getLogger()
+
+    logger.debug('Debug mode off')
+    logger.info(
+        f'Changing root logger level to {logging.getLevelName(level)}'
+    )
+
+    root_logger.setLevel(level)

--- a/src/graph_scheduler/utilities.py
+++ b/src/graph_scheduler/utilities.py
@@ -1,13 +1,18 @@
+import collections
 import inspect
 import logging
 import weakref
+from typing import Dict, Hashable, Set
 
-__all__ = []
+
+__all__ = ['clone_graph']
 
 
 logger = logging.getLogger(__name__)
 
 _unused_args_sig_cache = weakref.WeakKeyDictionary()
+
+typing_graph_dependency_dict = Dict[Hashable, Set[Hashable]]
 
 
 def prune_unused_args(func, args=None, kwargs=None):
@@ -84,3 +89,18 @@ def call_with_pruned_args(func, *args, **kwargs):
     """
     args, kwargs = prune_unused_args(func, args, kwargs)
     return func(*args, **kwargs)
+
+
+def clone_graph(graph: typing_graph_dependency_dict) -> typing_graph_dependency_dict:
+    """
+    Returns a copy of dependency-dict-formatted **graph** where the
+    nodes within are copied as references
+    """
+    res = {}
+    for k, v in graph.items():
+        if isinstance(v, collections.abc.Iterable) and not isinstance(v, str):
+            v = set(v)
+        else:
+            v = set([v])
+        res[k] = v
+    return res

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,29 @@
+import types
+
+import pytest
+
+import graph_scheduler as gs
+
+
+class HashableTestObject(types.SimpleNamespace):
+    def __hash__(self):
+        return hash(id(self))
+
+
+t1 = HashableTestObject()
+t2 = HashableTestObject()
+test_graphs = [
+    {t1: {1, 'A', t2}, 1: set(), 'A': {1}, t2: set()},
+]
+
+
+@pytest.mark.parametrize('graph', test_graphs)
+def test_clone_graph(graph):
+    res = gs.clone_graph(graph)
+
+    assert graph is not res
+    assert graph.keys() == res.keys()
+
+    for node in graph:
+        assert graph[node] == res[node]
+        assert graph[node] is not res[node]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -132,3 +132,14 @@ def test_convert_from_nx_graph(graph, nx_type):
     )
     assert nx_graph.nodes == nx_graph.nodes
     assert nx_graph.edges == res.edges
+
+
+@pytest.mark.parametrize('graph', test_graphs)
+@pytest.mark.parametrize('nx_type', nx_digraph_types)
+@pytest.mark.parametrize('format', ['png', 'jpg', 'svg'])
+def test_output_graph_image(graph, nx_type, format, tmp_path):
+    fname = f'{tmp_path}_fig.{format}'
+    nx_graph = graph_as_nx_graph(graph, nx_type)
+
+    gs.output_graph_image(graph, fname, format)
+    gs.output_graph_image(nx_graph, fname, format)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,13 +1,26 @@
+import logging
 import types
 
 import pytest
 
 import graph_scheduler as gs
 
+root_logger = logging.getLogger()
+gs_logger = logging.getLogger(gs.__name__)
+gs_utils_logger = logging.getLogger(gs.utilities.__name__)
+
+# root logger level may be modified elsewhere (currently is by psyneulink)
+orig_root_logger_level = root_logger.level
+
 
 class HashableTestObject(types.SimpleNamespace):
     def __hash__(self):
         return hash(id(self))
+
+
+class LogFilterAll(logging.Filter):
+    def filter(self, record):
+        return False
 
 
 t1 = HashableTestObject()
@@ -27,3 +40,57 @@ def test_clone_graph(graph):
     for node in graph:
         assert graph[node] == res[node]
         assert graph[node] is not res[node]
+
+
+@pytest.fixture(scope='function')
+def clean_logging(request):
+    def _reset_loggers():
+        root_logger.setLevel(orig_root_logger_level)
+        gs_logger.setLevel(logging.NOTSET)
+
+        for h in root_logger.handlers:
+            root_logger.removeHandler(h)
+
+        for h in gs_logger.handlers:
+            gs_logger.removeHandler(h)
+
+    filter_all = LogFilterAll()
+
+    request.addfinalizer(_reset_loggers)
+
+    gs_utils_logger.addFilter(filter_all)
+    yield
+    gs_utils_logger.removeFilter(filter_all)
+
+
+@pytest.mark.parametrize('disable_level', logging._levelToName.values())
+def test_debug_helpers(clean_logging, request, disable_level):
+    def assert_initialized_gs_logger_properties():
+        assert gs_logger.level == logging.NOTSET
+        assert len(gs_logger.handlers) == 1
+        assert gs_logger.handlers[0].level == logging.DEBUG
+
+    disable_level = getattr(logging, disable_level)
+
+    assert root_logger.level == orig_root_logger_level
+    assert gs_logger.level == logging.NOTSET
+
+    gs.enable_debug_logging()
+    assert_initialized_gs_logger_properties()
+    assert root_logger.level == logging.DEBUG
+
+    # check new handler not created on second call
+    gs.enable_debug_logging()
+    assert_initialized_gs_logger_properties()
+
+    gs.disable_debug_logging(disable_level)
+    assert_initialized_gs_logger_properties()
+    assert root_logger.level == disable_level
+
+    gs.enable_debug_logging()
+    assert_initialized_gs_logger_properties()
+    assert root_logger.level == logging.DEBUG
+
+    gs.disable_debug_logging()
+    assert_initialized_gs_logger_properties()
+    assert root_logger.level == logging.WARNING


### PR DESCRIPTION
- `clone_graph` - returns a semi-deep copy of a graph dependency dict (only node relations are deep-copied)
- `enable_debug_logging`, `disable_debug_logging` - simple interface for user to turn on and off python logging module
- `dependency_dict_to_networkx_digraph` - returns networkx.DiGraph given a graph dependency dict
- `networkx_digraph_to_dependency_dict` - returns a graph dependency dict given a networkx.DiGraph
- `output_graph_image` - writes an image representation of a graph to a file