### PR TITLE
Scheduler: correct graph construction

### DIFF
--- a/src/graph_scheduler/scheduler.py
+++ b/src/graph_scheduler/scheduler.py
@@ -420,7 +420,6 @@ class Scheduler:
         default_execution_id=None,
         mode: SchedulingMode = SchedulingMode.STANDARD,
         default_absolute_time_unit: Union[str, pint.Quantity] = _get_pint_unit(1, 'ms'),
-        **kwargs
     ):
         """
         :param self:

--- a/src/graph_scheduler/scheduler.py
+++ b/src/graph_scheduler/scheduler.py
@@ -315,7 +315,7 @@ from graph_scheduler.condition import (
     _parse_absolute_unit, _quantity_as_integer,
 )
 from graph_scheduler.time import _get_pint_unit, Clock, TimeScale
-from graph_scheduler.utilities import networkx_digraph_to_dependency_dict
+from graph_scheduler.utilities import clone_graph, networkx_digraph_to_dependency_dict
 
 __all__ = [
     'Scheduler', 'SchedulerError', 'SchedulingMode',
@@ -450,7 +450,11 @@ class Scheduler:
                 'Must instantiate a Scheduler with a graph dependency dict or a networkx.DiGraph'
             )
         else:
-            self.dependency_dict = graph
+            # add empty dependency set for senders that aren't present
+            self.dependency_dict = {
+                **{n: set() for n in set().union(*graph.values())},
+                **clone_graph(graph)
+            }
 
         self.consideration_queue = list(toposort(self.dependency_dict))
         self.nodes = []

--- a/src/graph_scheduler/scheduler.py
+++ b/src/graph_scheduler/scheduler.py
@@ -359,8 +359,12 @@ class Scheduler:
     ---------
 
     graph : Dict[object: set(object)], `networkx.DiGraph`
-        a graph specification dictionary - each entry of the dictionary must be an object,
-        and the value of each entry must be a set of zero or more objects that project directly to the key.
+        a directed acyclic graph (DAG). Specified as either:
+            - a graph specification dictionary: each entry of the
+            dictionary must be an object, and the value of each entry
+            must be a set of zero or more objects that project directly
+            to the key.
+            - a `networkx.DiGraph`
 
     conditions  : ConditionSet
         set of `Conditions <Condition>` that specify when individual nodes in **graph**
@@ -394,8 +398,10 @@ class Scheduler:
     consideration_queue_indices : dict
         a dict mapping **nodes** to their position in the `consideration_queue`
 
-    termination_conds : Dict[TimeScale: Condition]
-        a mapping from `TimeScales <TimeScale>` to `Conditions <Condition>` that, when met, terminate the execution
+    termination_conds : Dict[TimeScale: `Condition <graph_scheduler.condition.Condition>`]
+        a mapping from `TimeScales <TimeScale>` to `Conditions
+        <graph_scheduler.condition.Condition>` that, when met, terminate
+        the execution
         of the specified `TimeScale`. On set, update only for the
         `TimeScale`\\ s specified in the argument.
 

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -34,7 +34,7 @@ class TestScheduler:
                 stroop_consideration_queue
             ),
             (
-                nx.DiGraph(pytest.helpers.create_graph_from_pathways(*stroop_paths)),
+                nx.DiGraph(pytest.helpers.create_graph_from_pathways(*stroop_paths)).reverse(),
                 stroop_consideration_queue
             )
         ]


### PR DESCRIPTION
- must reverse networkx.DiGraph to get dependency dict
- must store all nodes as keys in dependency dict, even if they have no dependencies