### PR TITLE
Implement graph structure conditions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 networkx
 numpy >=1.19.0
+pandas
 pint
+scipy
 toposort

--- a/src/graph_scheduler/__init__.py
+++ b/src/graph_scheduler/__init__.py
@@ -30,7 +30,7 @@ for k, v in condition.__dict__.items():
         (
             k[0] != '_'
             and inspect.isclass(v)
-            and issubclass(v, condition.Condition)
+            and issubclass(v, condition.ConditionBase)
         )
         or k in condition._additional__all__
     ):

--- a/src/graph_scheduler/condition.py
+++ b/src/graph_scheduler/condition.py
@@ -552,6 +552,9 @@ class Condition:
             type(self).__name__, _get_condition_args_str(self.args, self.kwargs)
         )
 
+    def _validate_owner(self, value):
+        pass
+
     @property
     def owner(self):
         return self._owner
@@ -559,6 +562,7 @@ class Condition:
     @owner.setter
     def owner(self, value):
         logger.debug('Condition ({0}) setting owner to {1}'.format(type(self).__name__, value))
+        self._validate_owner(value)
         self._owner = value
 
     def is_satisfied(self, *args, execution_id=None, **kwargs):
@@ -620,8 +624,7 @@ class AbsoluteCondition(Condition):
 
 
 class _DependencyValidation:
-    @Condition.owner.setter
-    def owner(self, value):
+    def _validate_owner(self, value):
         try:
             # "dependency" or "dependencies" is always the first positional argument
             if not isinstance(self.args[0], collections.abc.Iterable) or isinstance(self.args[0], str):
@@ -637,8 +640,6 @@ class _DependencyValidation:
                     ' This may result in infinite loops or unknown behavior.',
                     stacklevel=5
                 )
-
-        self._owner = value
 
 
 #########################################################################################################

--- a/src/graph_scheduler/condition.py
+++ b/src/graph_scheduler/condition.py
@@ -13,6 +13,10 @@ nodes in a graph (e.g., whether or how many times they have executed). This pack
 `pre-specified Conditions <Condition_Pre_Specified>` that can be parametrized (e.g., how many times a node should
 be executed). `Custom conditions <Condition_Custom>` can also be created, by assigning a function to a Condition that
 can reference any node or its attributes, thus providing considerable flexibility for scheduling.
+These Conditions may also be referred to as "basic" Conditions.
+`Graph structure Conditions <Condition_Graph_Structure_Intro>` are distinct,
+and affect scheduling instead by modifying the base ordering in which
+nodes are considered for execution.
 
 .. _Condition_Creation:
 
@@ -27,11 +31,12 @@ Creating Conditions
 `Pre-specified Conditions <Condition_Pre-Specified_List>` can be instantiated and added to a :class:`Scheduler <graph_scheduler.scheduler.Scheduler>` at any time,
 and take effect immediately for the execution of that Scheduler. Most pre-specified Conditions have one or more
 arguments that must be specified to achieve the desired behavior. Many Conditions are also associated with an
-`owner <Condition.owner>` attribute (a node to which the Condition belongs). Schedulers maintain the data
+`owner <ConditionBase.owner>` attribute (a node to which the Condition
+belongs). Schedulers maintain the data
 used to test for satisfaction of Condition, independent in different `execution contexts <default_execution_id>`. The Scheduler is generally
 responsible for ensuring that Conditions have access to the necessary data.
 When pre-specified Conditions are instantiated within a call to the `add_condition` method of a `Scheduler` or `ConditionSet`,
-the Condition's `owner <Condition.owner>` is determined through
+the Condition's `owner <ConditionBase.owner>` is determined through
 context and assigned automatically, as in the following example::
 
     my_scheduler.add_condition(A, EveryNPasses(1))
@@ -73,17 +78,89 @@ the standard :class:`Condition` with ``node_A`` and ``epsilon`` as its arguments
 `NWhen` (which is satisfied the first N times after its condition becomes true),  The Condition is assigned to ``node_B``,
 thus scheduling it to execute one time when all of the elements of ``node_A`` have changed by less than ``epsilon``.
 
+
+.. _Condition_Graph_Structure_Intro:
+
+*Graph Structure Conditions*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Graph structure Conditions share the same interface as basic Conditions,
+but operate differently. Like basic Conditions, they are assigned to an
+`owner <GraphStructureCondition.owner>`, and like `node-based Conditions
+<Conditions_Node_Based>`, they also track other nodes. Each graph
+structure Condition represents a transformation that can be applied to a
+graph, adding and removing edges, which will result in modifying a
+Scheduler's `consideration queue <Scheduler_Algorithm>`. Some execution
+patterns that are difficult to create using basic Conditions can be
+achieved much more easily by making a simple change to the graph.
+
+.. _Condition_Graph_Structure_Example:
+
+For example, consider a situation in which a node computes an initial
+value and provides feedback to one or more of its ancestors. A direct
+construction of the scheduling graph with `D` providing feedback to `A`
+and `C` may be represented by::
+
+      D
+     ↗ ↖
+    B   C
+    ↑
+    A
+
+    {A: set(), B: {A}, C: set(), D: {B, C}}
+
+Creating a scheduling pattern for `D` to compute its initial
+value first, like `[{D}, {A, C}, {B}]`, would require several basic Conditions::
+
+    scheduler.add_condition(A, EveryNCalls(D, 1))
+    scheduler.add_condition(B, EveryNCalls(D, 1))
+    scheduler.add_condition(C, EveryNCalls(D, 1))
+    scheduler.add_condition(D, Always())
+
+This can become especially burdensome or impossible in larger graphs
+containing nodes that also need other Conditions. The same pattern would
+only require a single graph structure Condition::
+
+    scheduler.add_condition(D, BeforeNodes(A, C))
+
+which modifies the scheduler's graph to behave as if it were
+originally the following graph::
+
+    B
+    ↑
+    A   C
+     ↖ ↗
+      D
+
+    {A: {D}, B: {A}, C: {D}, D: set()}
+
+Not only is this easier, but it also allows the simultaneous use of the
+full range of basic Conditions.
+
+Of course, this is the same as if you created a scheduler using the
+second graph. What graph structure Conditions do is provide an interface
+that can be used to avoid manually producing and managing
+transformations of an existing, possibly complicated, graph.
+
+.. note::
+    Default behavior of graph structure conditions should be considered
+    in beta and subject to change.
+
+
 .. _Condition_Structure:
 
 Structure
 ---------
 
-The `Scheduler <graph_scheduler.scheduler.Scheduler>` associates every node with a Condition.  If a node has not been explicitly assigned a
+The `Scheduler <graph_scheduler.scheduler.Scheduler>` associates every
+node with a single basic Condition and zero or more `graph structure
+Conditions <Condition_Graph_Structure_Intro>`. If a node has not been
+explicitly assigned a
 Condition, it is assigned a Condition that causes it to be executed whenever it is `under consideration <Scheduler_Algorithm>`
 and all its structural parents have been executed at least once since the node's last execution.
 Condition subclasses (`listed below <Condition_Pre-Specified_List>`)
-provide a standard set of Conditions that can be implemented simply by specifying their parameter(s). There are
-six types:
+provide a standard set of Conditions that can be implemented simply by specifying their parameter(s).
+Along with graph structure Conditions, there are six types of basic Conditions:
 
   * `Generic <Conditions_Generic>` - satisfied when a `user-specified function and set of arguments <Condition_Custom>`
     evaluates to `True`;
@@ -266,6 +343,47 @@ specified `TimeScale` or `Time <Scheduler_Absolute_Time>`):
       satisfied on `ENVIRONMENT_STATE_UPDATE <TimeScale.ENVIRONMENT_STATE_UPDATE>` 0 of the specified `ENVIRONMENT_SEQUENCE` counted using 'TimeScale`
 
 
+.. _Conditions_Graph_Structure:
+
+**Graph Structure Conditions** (used to make modifications to the
+Scheduler graph):
+
+
+    * `BeforeNodes` (*nodes, **options)
+        adds a dependency from the owner to each of the specified nodes
+        and optionally modifies the senders and receivers of all
+        affected nodes
+
+    * `BeforeNode` (node, **options)
+        adds a dependency from the owner to the specified node and
+        optionally modifies the senders and receivers of both
+
+    * `WithNode` (node, **options)
+        adds a dependency from each of the senders of both the owner and
+        the specified node to both the owner and the specified node, and
+        optionally modifies the receivers of both
+
+    * `AfterNodes` (*nodes, **options)
+        adds a dependency from each of the specified nodes to the owner
+        and optionally modifies the senders and receivers of all
+        affected nodes
+
+    * `AfterNode` (node, **options)
+        adds a dependency from the specified node to the owner and
+        optionally modifies the senders and receivers of both
+
+    * `AddEdgeTo` (node)
+        adds an edge from `AddEdgeTo.owner <ConditionBase.owner>` to
+        `AddEdgeTo.node`
+
+    * `RemoveEdgeFrom` (node)
+        removes an edge from `RemoveEdgeFrom.node` to
+        `RemoveEdgeFrom.owner <ConditionBase.owner>`
+
+    * `CustomGraphStructureCondition` (callable, **kwargs)
+        applies a user-defined function to a graph
+
+
 .. Condition_Execution:
 
 Execution
@@ -273,7 +391,8 @@ Execution
 
 When the `Scheduler` `runs <Schedule_Execution>`, it makes a sequential `PASS` through its `consideration_queue`,
 evaluating each `consideration_set <consideration_set>` in the queue to determine which nodes should be assigned
-to execute. It evaluates the nodes in each set by calling the `is_satisfied` method of the Condition associated
+to execute. It evaluates the nodes in each set by calling the
+`is_satisfied` method of the basic Condition associated
 with each of those nodes.  If it returns `True`, then the node is assigned to the execution set for the
 `CONSIDERATION_SET_EXECUTION` of execution generated by that `PASS`.  Otherwise, the node is not executed.
 
@@ -284,25 +403,31 @@ Class Reference
 
 """
 
+import abc
 import collections
+import copy
+import enum
+import functools
+import inspect
 import itertools
 import logging
 import operator
 import warnings
-from typing import Union
+from typing import Callable, Dict, Hashable, Iterable, Set, Union
 
 import numpy as np
 import pint
 
 from graph_scheduler import _unit_registry
 from graph_scheduler.time import TimeScale
-from graph_scheduler.utilities import call_with_pruned_args
+from graph_scheduler.utilities import (
+    call_with_pruned_args, clone_graph, get_ancestors, get_descendants,
+    get_receivers, get_simple_cycles, typing_graph_dependency_dict,
+)
 
-
-_additional__all__ = ['ConditionError', 'ConditionSet']
+_additional__all__ = ['ConditionError', 'ConditionSet', 'Operation']
 
 logger = logging.getLogger(__name__)
-
 
 _pint_all_time_units = sorted(
     set([
@@ -320,6 +445,9 @@ comparison_operators = {
     '==': operator.eq,
     '!=': operator.ne
 }
+
+
+typing_subject_operation = Union['Operation', str, Dict[Hashable, Union['Operation', str]]]
 
 
 def _quantity_as_integer(q):
@@ -403,12 +531,89 @@ def _get_condition_args_str(*args):
     return ', '.join(args_str)
 
 
-class ConditionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class Operation(enum.Enum):
+    """
+    Used in conjunction with `GraphStructureCondition` to indicate how a
+    set of source nodes (**S** below) should be combined with a set of
+    comparison nodes (**C** below) to produce a result set. Many
+    Operations correspond to standard set operations.
 
-    def __str__(self):
-        return repr(self.error_value)
+    Each enum item can be called with a source set and comparison set as
+    arguments to produce the result set.
+
+    Attributes:
+        KEEP: Returns **S**
+
+        REPLACE: Returns **C**
+
+        DISCARD: Returns the empty set
+
+        INTERSECTION: Returns the set of items that are in both **S**
+            and **C**
+
+        UNION: Returns the set of items in either **S** or **C**
+
+        MERGE: Returns the set of items in either **S** or **C**
+
+        DIFFERENCE: Returns the set of items in **S** but not **C**
+
+        INVERSE_DIFFERENCE: Returns the set of items in **C** but not
+            **S**
+
+        SYMMETRIC_DIFFERENCE: Returns the set of items that are in one
+            of **S** or **C** but not both
+
+    """
+    def _keep(s, c):
+        return s
+
+    def _replace(s, c):
+        return c
+
+    def _discard(s, c):
+        return set()
+
+    def _inverse_difference(s, c):
+        return c.difference(s)
+
+    KEEP = functools.partial(_keep)
+    REPLACE = functools.partial(_replace)
+    DISCARD = functools.partial(_discard)
+    INTERSECTION = functools.partial(set.intersection)
+    UNION = functools.partial(set.union)
+    MERGE = functools.partial(set.union)
+    DIFFERENCE = functools.partial(set.difference)
+    INVERSE_DIFFERENCE = functools.partial(_inverse_difference)
+    SYMMETRIC_DIFFERENCE = functools.partial(set.symmetric_difference)
+
+    @classmethod
+    def _str_max_length(cls):
+        # "Operation.<max member name>"
+        return max(len(a) for a in cls.__members__) + len(cls.__name__) + 1
+
+    def __call__(
+        self, source_neighbors: Set[Hashable], comparison_neighbors: Set[Hashable]
+    ) -> Set[Hashable]:
+        """
+        Returns the set resulting from applying an `Operation` on
+        **source_neighbors** and **comparison_neighbors**
+
+        Args:
+            source_neighbors (Set[Hashable])
+            comparison_neighbors (Set[Hashable])
+
+        Returns:
+            Set[Hashable]
+        """
+        res = self.value(source_neighbors, comparison_neighbors)
+        logger.debug(
+            f'{self} applied to {source_neighbors} against {comparison_neighbors} giving {res}'
+        )
+        return res
+
+
+class ConditionError(Exception):
+    pass
 
 
 class ConditionSet(object):
@@ -458,7 +663,7 @@ class ConditionSet(object):
         )
 
     def __iter__(self):
-        return iter(self.conditions)
+        return filter(lambda c: isinstance(c, Condition), self.conditions)
 
     def __getitem__(self, key):
         return self.conditions[key]
@@ -489,6 +694,7 @@ class ConditionSet(object):
             pass
         else:
             warnings.warn(f'Replacing condition for {owner}. old: {old_condition} new: {condition}')
+
         self.conditions[owner] = condition
 
     def add_condition_set(self, conditions):
@@ -513,7 +719,39 @@ class ConditionSet(object):
             self.add_condition(owner, conditions[owner])
 
 
-class Condition:
+class ConditionBase:
+    """
+    Abstract base class for `basic conditions
+    <graph_scheduler.condition.Condition>` and `graph structure
+    conditions <GraphStructureCondition>`
+
+    Attributes:
+        owner (Hashable):
+            the node with which the Condition is associated, and the
+            execution of which it determines.
+
+    """
+    def __init__(self, _owner: Hashable = None, **kwargs):
+        self._owner = _owner
+        self.kwargs = kwargs
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def _validate_owner(self, value):
+        pass
+
+    @property
+    def owner(self):
+        return self._owner
+
+    @owner.setter
+    def owner(self, value):
+        logger.debug('{0} setting owner to {1}'.format(self, value))
+        self._validate_owner(value)
+        self._owner = value
+
+
+class Condition(ConditionBase):
     """
     Used in conjunction with a :class:`Scheduler` to specify the condition under which a node should be
     allowed to execute.
@@ -529,41 +767,16 @@ class Condition:
 
     kwargs : **kwargs
         specifies keyword arguments to pass to `func` when the Condition is evaluated.
-
-    Attributes
-    ----------
-
-    owner (node):
-        the node with which the Condition is associated, and the execution of which it determines.
-
     """
     def __init__(self, func, *args, **kwargs):
         self.func = func
         self.args = args
-        self.kwargs = kwargs
-
-        self._owner = None
-
-        for k in kwargs:
-            setattr(self, k, kwargs[k])
+        super().__init__(**kwargs)
 
     def __str__(self):
         return '{0}({1})'.format(
             type(self).__name__, _get_condition_args_str(self.args, self.kwargs)
         )
-
-    def _validate_owner(self, value):
-        pass
-
-    @property
-    def owner(self):
-        return self._owner
-
-    @owner.setter
-    def owner(self, value):
-        logger.debug('Condition ({0}) setting owner to {1}'.format(type(self).__name__, value))
-        self._validate_owner(value)
-        self._owner = value
 
     def is_satisfied(self, *args, execution_id=None, **kwargs):
         """
@@ -640,7 +853,6 @@ class _DependencyValidation:
                     ' This may result in infinite loops or unknown behavior.',
                     stacklevel=5
                 )
-
 
 #########################################################################################################
 # Included Conditions
@@ -2126,3 +2338,916 @@ class Threshold(_DependencyValidation, Condition):
         else:
             if not hasattr(dependency, parameter):
                 raise ConditionError(f'{dependency} has no {parameter} attribute')
+
+
+######################################################################
+# Graph Structure Conditions
+######################################################################
+class GraphStructureCondition(ConditionBase, metaclass=abc.ABCMeta):
+    """
+    Abstract base class for `graph structure conditions
+    <Condition_Graph_Structure_Intro>`
+
+    Subclasses must implement:
+        `_process`
+    """
+    def _validate_graph(self, graph):
+        """
+        Called in `modify_graph` in order to raise any errors or
+        warnings regarding **graph** with respect to this condition's
+        attributes.
+
+        Args:
+            graph: a graph dependency dictionary
+        """
+        pass
+
+    def _preprocess(self, graph):
+        """
+        Hook for changes to **graph** that occur before the main
+        `GraphStructureCondition._process` method
+
+        Args:
+            graph: clone of graph from
+                `GraphStructureCondition._modify_graph`
+        """
+        return graph
+
+    @abc.abstractmethod
+    def _process(self, graph):
+        """
+        Primary internal method used to perform modifications on
+        **graph**. Receives result of
+        GraphStructureCondition._preprocess`
+
+        Args:
+            graph: cloned result graph from
+                `GraphStructureCondition._preprocess`
+        """
+        return graph
+
+    def _postprocess(self, graph, base_graph):
+        """
+        Hook for changes to **graph** that occur after the main
+        `GraphStructureCondition._process` method.
+
+        Args:
+            graph: cloned result graph from
+                `GraphStructureCondition._preprocess`
+            base_graph: original graph from
+                `GraphStructureCondition._modify_graph`, which was not
+                modified by`GraphStructureCondition._preprocess`
+        """
+        return graph
+
+    def modify_graph(
+        self, graph: typing_graph_dependency_dict
+    ) -> typing_graph_dependency_dict:
+        """
+        Modifies **graph** based on the transformation specified by this
+        condition
+
+        Args:
+            graph: a graph dependency dictionary
+
+        Raises:
+            ConditionError
+
+        Returns:
+            A copy of **graph** with modifications applied
+        """
+        if self.owner is None:
+            raise ConditionError(
+                "owner must be assigned before modify_graph is called"
+            )
+        self._validate_graph(graph)
+        return self._modify_graph(graph)
+
+    def _modify_graph(self, graph):
+        result_graph = self._preprocess(clone_graph(graph))
+        logger.debug(f'Modified graph after _preprocess: {result_graph}')
+
+        result_graph = self._process(result_graph)
+        logger.debug(f'Modified graph after _process: {result_graph}')
+
+        result_graph = self._postprocess(result_graph, graph)
+        logger.debug(f'Modified graph after _postprocess: {result_graph}')
+
+        return result_graph
+
+
+class CustomGraphStructureCondition(GraphStructureCondition):
+    """
+    Applies a user-defined function to a graph
+
+    Args:
+        process_graph_function (Callable): a function taking an optional
+            'self' argument (as the first argument, if present), and a
+            graph dependency dictionary
+        kwargs (**kwargs): optional arguments to be stored as attributes
+    """
+    def __init__(
+        self, process_graph_function: Callable, **kwargs
+    ):
+        if not callable(process_graph_function):
+            raise ConditionError(
+                'process_graph_function must be a callable that takes and'
+                ' returns a graph dependency dictionary'
+            )
+        super().__init__(
+            process_graph_function=process_graph_function, **kwargs
+        )
+
+    def _process(self, graph):
+        graph = super()._process(graph)
+
+        sig = inspect.signature(self.process_graph_function)
+        if 'self' in sig.parameters:
+            if next(iter(sig.parameters)) != 'self':
+                raise ConditionError(
+                    "If using 'self' in process_graph_function, it must be the first argument"
+                )
+            return self.process_graph_function(self, graph)
+        else:
+            return self.process_graph_function(graph)
+
+
+class _GSCUsingNodes(GraphStructureCondition):
+    """
+    Attributes:
+        nodes: the subject nodes
+    """
+    def __init__(self, *nodes: Hashable, **kwargs):
+        self._validate_nodes(nodes)
+        super().__init__(nodes=nodes, **kwargs)
+
+    def __str__(self):
+        return '{0}({1})'.format(
+            type(self).__name__,
+            _get_condition_args_str(
+                # do not use kwarg for 'nodes' to be consistent with other Conditions
+                self.nodes,
+                {k: v for k, v in self.kwargs.items() if k != 'nodes'},
+            ),
+        )
+
+    def _validate_owner(self, value):
+        if value in self.nodes:
+            raise ConditionError(
+                f'{value} cannot be assigned as owner of {self} because it is a'
+                f' subject node of {self}'
+            )
+
+    def _validate_nodes(self, nodes):
+        if len(nodes) < 1:
+            raise ConditionError(
+                f'{type(self).__name__} must have at least one node'
+            )
+        unhashable = []
+        for n in nodes:
+            try:
+                hash(n)
+            except Exception:
+                unhashable.append(n)
+
+        if len(unhashable) > 0:
+            raise ConditionError(f'All nodes must be hashable. Unhashable: {unhashable}')
+
+    def _validate_graph(self, graph):
+        nodes_used = {self.owner}.union(self.nodes)
+        nodes_not_in_graph = set.difference(nodes_used, set(graph.keys()))
+        if len(nodes_not_in_graph) > 0:
+            raise ConditionError(
+                'nodes used by {0} are missing from graph: {1}'.format(
+                    self, nodes_not_in_graph
+                )
+            )
+
+
+class _GSCSingleNode(_GSCUsingNodes):
+    """
+    Attributes:
+        node: the subject node
+    """
+    def _validate_nodes(self, nodes):
+        if len(nodes) != 1:
+            raise ConditionError(
+                f'{type(self).__name__} must have exactly one node'
+            )
+
+        super()._validate_nodes(nodes)
+
+    @property
+    def node(self):
+        return self.nodes[0]
+
+
+class _GSCWithOperations(_GSCUsingNodes):
+    """
+    Args:
+        owner_senders: `Operation` that determines how the original
+            senders of `owner <ConditionBase.owner>` (the Operation
+            source) combine with the union of all original senders of
+            all subject `nodes <_GSCUsingNodes.nodes>` (the
+            Operation comparison) to produce the new set of senders of
+            `owner <ConditionBase.owner>` after `modify_graph`
+        owner_receivers: `Operation` that determines how the
+            original receivers of `owner <ConditionBase.owner>` (the
+            Operation source) combine with the union of all original
+            receivers of all subject `nodes
+            <_GSCUsingNodes.nodes>` (the Operation comparison)
+            to produce the new set of receivers of `owner
+            <ConditionBase.owner>` after `modify_graph`
+        subject_senders: `Operation` that determines how the
+            original senders for each of the subject `nodes
+            <_GSCUsingNodes.nodes>` (the Operation source) combine with
+            the original senders of `owner <ConditionBase.owner>` (the
+            Operation comparison) to produce the new set of senders for
+            the subject `nodes <_GSCUsingNodes.nodes>` after
+            `modify_graph`. Operations are applied individually to each
+            subject node, and this argument may also be specified as a
+            dictionary mapping nodes to separate operations.
+        subject_receivers: `Operation` that determines how the
+            original receivers for each of the subject `nodes
+            <_GSCUsingNodes.nodes>` (the Operation source) combine with
+            the original receivers of `owner <ConditionBase.owner>` (the
+            Operation comparison) to produce the new set of receivers
+            for the subject `nodes <_GSCUsingNodes.nodes>` after
+            `modify_graph`. Operations are applied individually to each
+            subject node, and this argument may also be specified as a
+            dictionary mapping nodes to separate operations.
+        reconnect_non_subject_receivers: If True, `modify_graph`
+            will create an edge from all prior senders of `owner` to
+            all receivers of `owner` that are not in `nodes`, if
+            there is no longer a path from that sender to that
+            receiver.
+            Defaults to True.
+        remove_new_self_referential_edges: If True, `modify_graph`
+            will remove any newly-created edges from a node to
+            itself.
+            Defaults to True.
+        prune_cycles: If True, `modify_graph` will attempt to prune
+            any newly-created cycles, preferring to remove edges
+            adjacent to `owner` that affect the placement of `owner`
+            more than any subject `node <nodes>`.
+            Defaults to True.
+        ignore_conflicts: If True, when any two operations give
+            different results for the new senders and receivers of a
+            node in `modify_graph`, an error will not be raised.
+            Defaults to False.
+    """
+    __doc__ += _GSCUsingNodes.__doc__
+
+    def __init__(
+        self,
+        *nodes: Hashable,
+        owner_senders: Union[Operation, str] = Operation.KEEP,
+        owner_receivers: Union[Operation, str] = Operation.KEEP,
+        subject_senders: typing_subject_operation = Operation.KEEP,
+        subject_receivers: typing_subject_operation = Operation.KEEP,
+        reconnect_non_subject_receivers: bool = True,
+        remove_new_self_referential_edges: bool = True,
+        prune_cycles: bool = True,
+        ignore_conflicts: bool = False,
+        **kwargs,
+    ):
+        owner_senders = self._parse_operation_arg(owner_senders)
+        owner_receivers = self._parse_operation_arg(owner_receivers)
+        subject_senders = self._handle_subject_arg(
+            subject_senders, nodes, is_senders=True,
+        )
+        subject_receivers = self._handle_subject_arg(
+            subject_receivers, nodes, is_senders=False
+        )
+
+        super().__init__(
+            *nodes,
+            owner_senders=owner_senders,
+            owner_receivers=owner_receivers,
+            subject_senders=subject_senders,
+            subject_receivers=subject_receivers,
+            reconnect_non_subject_receivers=reconnect_non_subject_receivers,
+            remove_new_self_referential_edges=remove_new_self_referential_edges,
+            prune_cycles=prune_cycles,
+            ignore_conflicts=ignore_conflicts,
+            **kwargs
+        )
+
+    def _get_subject_operation(
+        self,
+        operation: Union[Operation, Dict[Hashable, Operation]],
+        subject: Hashable,
+    ) -> Operation:
+        """
+        Parses **operation** in possible dict form for the operation to
+        be applied to **subject**.
+
+        Args:
+            operation (Union[Operation, Dict[Hashable, Operation]])
+            subject (Hashable)
+
+        Raises:
+            ConditionError
+
+        Returns:
+            Operation
+        """
+        try:
+            return operation[subject]
+        except TypeError:
+            return operation
+        except KeyError as e:
+            raise ConditionError(
+                'If specifying subject operations in a dict, must include an'
+                f' operation for each subject node. Missing: {e}'
+            ) from e
+
+    def _get_conflict_application_string(
+        self,
+        operation_arg_name: str,
+        applied_to: Hashable,
+        sources: Iterable[Hashable],
+        comparisons: Iterable[Hashable]
+    ) -> str:
+        """
+        Args:
+            operation_arg_name (str): name of the operation attribute
+            applied_to (Hashable): node whose neighbors are being
+                modified
+            sources (Iterable[Hashable]): the original
+                neighbors of **applied_to** comparisons
+            (Iterable[Hashable]): the original neighbors of the other
+                node relevant to the operation attribute
+
+        Returns:
+            str: a string describing the application of a single
+                operation, to be used in generating errors.
+        """
+        operation = getattr(self, operation_arg_name)
+        try:
+            operation = self._get_subject_operation(operation, applied_to)
+        except ConditionError:
+            pass
+
+        try:
+            sources = sorted(sources)
+        except TypeError:
+            pass
+
+        try:
+            comparisons = sorted(comparisons)
+        except TypeError:
+            pass
+
+        sources_str = ','.join(sources) if len(sources) else '{}'
+        comparisons_str = ','.join(comparisons) if len(comparisons) else '{}'
+
+        return '\t{0} {1} applied on {2} with {3} against {4}'.format(
+            str(operation_arg_name).ljust(self._operations_names_max_length()),
+            f'({operation})'.ljust(Operation._str_max_length() + 2),
+            applied_to,
+            sources_str,
+            comparisons_str,
+        )
+
+    def _get_edge_conflicts(
+        self, sender, receiver, new_sender_nodes, new_receiver_nodes, old_sender_nodes, old_receiver_nodes
+    ):
+        if receiver is self.owner:
+            sender_operation = 'owner_senders'
+            sender_sources = old_sender_nodes[self.owner]
+            sender_comparisons = set().union(*[old_sender_nodes[n] for n in self.nodes])
+        else:
+            sender_operation = 'subject_senders'
+            sender_sources = old_sender_nodes[receiver]
+            sender_comparisons = old_sender_nodes[self.owner]
+
+        if sender is self.owner:
+            receiver_operation = 'owner_receivers'
+            receiver_sources = old_receiver_nodes[self.owner]
+            receiver_comparisons = set().union(*[old_receiver_nodes[n] for n in self.nodes])
+        else:
+            receiver_operation = 'subject_receivers'
+            receiver_sources = old_receiver_nodes[sender]
+            receiver_comparisons = old_receiver_nodes[self.owner]
+
+        conflict_strings = []
+
+        if (
+            receiver in new_sender_nodes
+            and (
+                sender in new_sender_nodes[receiver]
+                and (sender in new_receiver_nodes and receiver not in new_receiver_nodes[sender])
+            )
+        ):
+            conflict_strings.append(
+                '{0} {1}\n{2} {3}'.format(
+                    self._get_conflict_application_string(sender_operation, receiver, sender_sources, sender_comparisons),
+                    f'makes {sender} a sender of {receiver}',
+                    self._get_conflict_application_string(receiver_operation, sender, receiver_sources, receiver_comparisons),
+                    f'does not make {receiver} a receiver of {sender}',
+                )
+            )
+        elif (
+            sender in new_receiver_nodes
+            and (
+                receiver in new_receiver_nodes[sender]
+                and (receiver in new_sender_nodes and sender not in new_sender_nodes[receiver])
+            )
+        ):
+            conflict_strings.append(
+                '{0} {1}\n{2} {3}'.format(
+                    self._get_conflict_application_string(receiver_operation, sender, receiver_sources, receiver_comparisons),
+                    f'makes {receiver} a receiver of {sender}',
+                    self._get_conflict_application_string(sender_operation, receiver, sender_sources, sender_comparisons),
+                    f'does not make {sender} a sender of {receiver}',
+                )
+            )
+
+        return conflict_strings
+
+    def _postprocess(self, graph, base_graph):
+        graph = self._handle_remove_new_self_referential_edges(graph, base_graph)
+        graph = super()._postprocess(graph, base_graph)
+        graph = self._handle_prune_cycles(graph, base_graph)
+        graph = self._handle_reconnect_non_subject_receivers(graph, base_graph)
+        return graph
+
+    def _handle_reconnect_non_subject_receivers(self, graph, base_graph):
+        if self.reconnect_non_subject_receivers:
+            orig_owner_sender_nodes = base_graph[self.owner]
+            orig_receivers_old = get_receivers(base_graph)
+
+            for sender in orig_owner_sender_nodes:
+                for receiver in orig_receivers_old[self.owner]:
+                    if (
+                        receiver not in self.nodes
+                        and self.owner in base_graph[receiver]
+                        and sender in base_graph[self.owner]
+                        and (
+                            self.owner not in graph[receiver]
+                            or sender not in graph[self.owner]
+                        )
+                        and sender not in get_descendants(graph)[receiver]
+                    ):
+                        graph[receiver].add(sender)
+                        logger.debug(
+                            f'Reconnecting {receiver} as receiver of {sender}'
+                        )
+        return graph
+
+    def _handle_remove_new_self_referential_edges(self, graph, base_graph):
+        if self.remove_new_self_referential_edges:
+            for node in graph:
+                if node not in base_graph[node]:
+                    if node in graph[node]:
+                        graph[node].remove(node)
+                        logger.debug(f'New self-referential edge removed for {node}')
+        return graph
+
+    def _is_required_edge(self, sender, receiver):
+        return False
+
+    def _prune_owner_edge(self, owner_idx, cycle, graph, base_graph):
+        len_cycle = len(cycle)
+        assert cycle[owner_idx % len_cycle] is self.owner
+
+        owner_is_full_ancestor = True
+        owner_is_full_descendant = True
+
+        # if any of self.nodes are in cycle, only check if owner is an
+        # ancestor/descendant of those nodes, otherwise check all
+        nodes_in_cycle = [n for n in self.nodes if n in cycle]
+        nodes_to_check = nodes_in_cycle if len(nodes_in_cycle) else self.nodes
+        ancestors = get_ancestors(base_graph)
+        descendants = get_descendants(base_graph)
+        for n in nodes_to_check:
+            if self.owner not in ancestors[n]:
+                owner_is_full_ancestor = False
+            if self.owner not in descendants[n]:
+                owner_is_full_descendant = False
+
+        # if owner is an ancestor of all relevant nodes or they are
+        # unrelated/mixed, prune its outgoing edge. This favors
+        # displacing owner more than other nodes.
+        if owner_is_full_ancestor or not owner_is_full_descendant:
+            sender = self.owner
+            receiver = cycle[(owner_idx + 1) % len_cycle]
+        else:
+            sender = cycle[(owner_idx - 1) % len_cycle]
+            receiver = self.owner
+
+        if sender in graph[receiver] and not self._is_required_edge(sender, receiver):
+            graph[receiver].remove(sender)
+            logger.debug(f'Pruning edge {sender} to {receiver} in cycle {cycle}')
+
+    def _handle_prune_cycles(self, graph, base_graph):
+        if not self.prune_cycles:
+            return graph
+
+        prev_cycles = list(get_simple_cycles(graph))
+
+        while len(prev_cycles) > 0:
+            cycles = list(get_simple_cycles(graph))
+
+            for c in sorted(prev_cycles, key=lambda x: -len(x)):
+                if c not in cycles:
+                    logger.debug(f'Cycle {c} already resolved')
+                    continue
+
+                len_c = len(c)
+                for i in range(len_c):
+                    sender = c[i]
+                    receiver_idx = (i + 1) % len_c
+                    receiver = c[receiver_idx]
+
+                    if receiver is self.owner:
+                        self._prune_owner_edge(receiver_idx, c, graph, base_graph)
+                    elif (
+                        receiver in base_graph[sender]
+                        and sender is not self.owner
+                        and not self._is_required_edge(sender, receiver)
+                    ):
+                        # may have been removed in another cycle
+                        if sender in graph[receiver]:
+                            graph[receiver].remove(sender)
+                            logger.debug(
+                                f'Pruning edge {sender} to {receiver} in simple'
+                                f'cycle not involving owner {c}'
+                            )
+
+                cycles = list(get_simple_cycles(graph))
+
+            if prev_cycles == cycles:
+                logger.debug(f'Failed to prune all cycles, remaining: {cycles}')
+                break
+
+            prev_cycles = cycles
+
+        return graph
+
+    def _process(self, graph):
+        graph = super()._process(graph)
+
+        old_receiver_nodes = get_receivers(graph)
+        old_owner_sender_nodes = graph[self.owner]
+        old_subject_sender_nodes = {n: graph[n] for n in self.nodes}
+        new_sender_nodes = {}
+        new_receiver_nodes = {}
+        conflict_strings = []
+        result_graph = clone_graph(graph)
+
+        logger.debug(f'Apply owner_senders ({self.owner_senders}) to {self.owner}')
+        new_sender_nodes[self.owner] = self.owner_senders(
+            old_owner_sender_nodes,
+            set.union(*old_subject_sender_nodes.values()),
+        )
+        logger.debug(f'Apply owner_receivers ({self.owner_receivers}) to {self.owner}')
+        new_receiver_nodes[self.owner] = self.owner_receivers(
+            old_receiver_nodes[self.owner],
+            set.union(*[old_receiver_nodes[n] for n in self.nodes]),
+        )
+
+        for n in self.nodes:
+            subject_senders_n = self._get_subject_operation(self.subject_senders, n)
+            subject_receivers_n = self._get_subject_operation(self.subject_receivers, n)
+
+            logger.debug(f'Apply subject_senders ({subject_senders_n}) to {n}')
+            new_sender_nodes[n] = subject_senders_n(
+                old_subject_sender_nodes[n],
+                old_owner_sender_nodes,
+            )
+            logger.debug(f'Apply subject_receivers ({subject_receivers_n}) to {n}')
+            new_receiver_nodes[n] = subject_receivers_n(
+                old_receiver_nodes[n],
+                old_receiver_nodes[self.owner],
+            )
+
+        for receiver in new_sender_nodes:
+            if not self.ignore_conflicts:
+                for sender in new_sender_nodes[receiver]:
+                    edge_conflicts = self._get_edge_conflicts(
+                        sender, receiver, new_sender_nodes, new_receiver_nodes, graph, old_receiver_nodes
+                    )
+                    conflict_strings.extend(edge_conflicts)
+            result_graph[receiver] = new_sender_nodes[receiver]
+
+        # sender has an operation that changes its receiver nodes
+        # ([owner/subject]_receiver)
+        for sender in new_receiver_nodes:
+            for node in graph:
+                # [owner/subject]_receiver operation applied to sender includes node
+                if node in new_receiver_nodes[sender]:
+                    if not self.ignore_conflicts:
+                        edge_conflicts = self._get_edge_conflicts(
+                            sender, node, new_sender_nodes, new_receiver_nodes, graph, old_receiver_nodes
+                        )
+                        conflict_strings.extend(edge_conflicts)
+                    result_graph[node].add(sender)
+                    logger.debug(
+                        f'{node} is a new receiver of {sender} - adding to modified graph.'
+                    )
+                # [owner/subject]_receiver operation applied to sender does not include node
+                else:
+                    try:
+                        result_graph[node].remove(sender)
+                    except KeyError:
+                        pass
+                    else:
+                        logger.debug(
+                            f'{node} is not a new receiver of {sender} - discarding from modified graph.'
+                        )
+
+        if not self.ignore_conflicts and len(conflict_strings) > 0:
+            err_prefix = 'Conflict between operations:\n'
+            raise ConditionError(err_prefix + '\n\t-----\n'.join(conflict_strings))
+
+        return result_graph
+
+    @staticmethod
+    def _parse_operation_arg(operation):
+        try:
+            return Operation.__members__[str.upper(operation)]
+        except (KeyError, TypeError):
+            return operation
+
+    def _handle_subject_arg(
+        self,
+        subject: typing_subject_operation,
+        nodes: Iterable[Hashable],
+        is_senders: bool,
+    ):
+        if is_senders:
+            operation_arg_name = 'subject_senders'
+        else:
+            operation_arg_name = 'subject_receivers'
+
+        if isinstance(subject, dict):
+            for n, v in subject.items():
+                if n not in nodes:
+                    raise ConditionError(
+                        f'{_format_arg(n)} in {operation_arg_name} but not in nodes {nodes}'
+                    )
+                subject[n] = self._parse_operation_arg(v)
+
+            nodes_missing_subject_operations = subject.keys() - set(nodes)
+            if len(nodes_missing_subject_operations) > 0:
+                raise ConditionError(
+                    f'{operation_arg_name} specified as a dict but does not'
+                    ' have an operation for each node. Missing:'
+                    f' {nodes_missing_subject_operations}'
+                )
+        else:
+            subject = self._parse_operation_arg(subject)
+
+        return subject
+
+    @classmethod
+    def _operations_names_max_length(cls):
+        sig = inspect.signature(cls)
+        return max(
+            len(operations_param_name)
+            for operations_param_name, sig_param
+            in sig.parameters.items()
+            if isinstance(sig_param.default, Operation)
+        )
+
+
+class _GSCReposition(_GSCUsingNodes):
+    _already_valid_message = 'valid compared to'
+
+    @abc.abstractmethod
+    def _nodes_already_valid(self, graph):
+        return []
+
+    def _validate_graph(self, graph):
+        super()._validate_graph(graph)
+
+        already_valid = self._nodes_already_valid(graph)
+        try:
+            already_valid = sorted(already_valid)
+        except TypeError:
+            pass
+
+        if len(already_valid) > 0:
+            if len(already_valid) == len(self.nodes):
+                ignored_message = ' Condition is ignored.'
+            else:
+                ignored_message = ''
+
+            warnings.warn(
+                '{0}: {1} is already {2} {3} in graph {4}.{5}'.format(
+                    self,
+                    self.owner,
+                    self._already_valid_message,
+                    ','.join(already_valid),
+                    graph,
+                    ignored_message,
+                )
+            )
+
+    def _preprocess(self, graph):
+        # remove any owner <-> subject edges - any that are needed are
+        # added in subclass _process methods
+        for n in self.nodes:
+            graph[n].discard(self.owner)
+            graph[self.owner].discard(n)
+        return graph
+
+    def _modify_graph(self, graph):
+        graph = clone_graph(graph)
+        if len(self._nodes_already_valid(graph)) == len(self.nodes):
+            return graph
+
+        return super()._modify_graph(graph)
+
+
+class BeforeNodes(_GSCReposition, _GSCWithOperations):
+    """
+    Adds a dependency from the owner to each of the specified nodes and
+    optionally modifies the senders and receivers of all affected nodes
+    """
+    __doc__ += _GSCWithOperations.__doc__
+    _already_valid_message = 'before'
+
+    def __init__(
+        self,
+        *nodes,
+        owner_senders: Union[Operation, str] = Operation.MERGE,
+        owner_receivers: Union[Operation, str] = Operation.KEEP,
+        subject_senders: typing_subject_operation = Operation.KEEP,
+        subject_receivers: typing_subject_operation = Operation.KEEP,
+        reconnect_non_subject_receivers: bool = True,
+        remove_new_self_referential_edges: bool = True,
+        prune_cycles: bool = True,
+        ignore_conflicts: bool = False,
+    ):
+        super().__init__(
+            *nodes,
+            owner_senders=owner_senders,
+            owner_receivers=owner_receivers,
+            subject_senders=subject_senders,
+            subject_receivers=subject_receivers,
+            reconnect_non_subject_receivers=reconnect_non_subject_receivers,
+            remove_new_self_referential_edges=remove_new_self_referential_edges,
+            prune_cycles=prune_cycles,
+            ignore_conflicts=ignore_conflicts,
+        )
+
+    def _nodes_already_valid(self, graph):
+        return [n for n in self.nodes if self.owner in graph[n]]
+
+    def _is_required_edge(self, sender, receiver):
+        return sender is self.owner and receiver in self.nodes
+
+    def _process(self, graph):
+        graph = super()._process(graph)
+
+        for n in self.nodes:
+            graph[n].add(self.owner)
+
+        return graph
+
+
+class BeforeNode(BeforeNodes, _GSCSingleNode):
+    """
+    Adds a dependency from the owner to the specified node and
+    optionally modifies the senders and receivers of both
+    """
+    __doc__ += _GSCWithOperations.__doc__
+    __doc__ += _GSCSingleNode.__doc__
+    pass
+
+
+class WithNode(_GSCReposition, _GSCWithOperations, _GSCSingleNode):
+    """
+    Adds a dependency from each of the senders of both the owner and the
+    specified node to both the owner and the specified node, and
+    optionally modifies the receivers of both
+    """
+    __doc__ += _GSCWithOperations.__doc__
+    __doc__ += _GSCSingleNode.__doc__
+    _already_valid_message = 'with'
+
+    def __init__(
+        self,
+        node,
+        owner_receivers: Union[Operation, str] = Operation.KEEP,
+        subject_receivers: typing_subject_operation = Operation.KEEP,
+        reconnect_non_subject_receivers: bool = True,
+        remove_new_self_referential_edges: bool = True,
+        prune_cycles: bool = True,
+        ignore_conflicts: bool = False,
+    ):
+        super().__init__(
+            node,
+            owner_senders=Operation.MERGE,
+            owner_receivers=owner_receivers,
+            subject_senders=Operation.MERGE,
+            subject_receivers=subject_receivers,
+            reconnect_non_subject_receivers=reconnect_non_subject_receivers,
+            remove_new_self_referential_edges=remove_new_self_referential_edges,
+            prune_cycles=prune_cycles,
+            ignore_conflicts=ignore_conflicts,
+        )
+
+    def _nodes_already_valid(self, graph):
+        return [n for n in self.nodes if graph[n] == graph[self.owner]]
+
+    def _is_required_edge(self, sender, receiver):
+        return receiver is self.node or receiver is self.owner
+
+    def _process(self, graph):
+        graph = super()._process(graph)
+
+        all_senders = graph[self.owner].union(graph[self.node])
+        graph[self.owner] = all_senders
+        graph[self.node] = copy.copy(all_senders)
+
+        return graph
+
+
+class AfterNodes(_GSCReposition, _GSCWithOperations):
+    """
+    Adds a dependency from each of the specified nodes to the owner
+    and optionally modifies the senders and receivers of all
+    affected nodes
+    """
+    __doc__ += _GSCWithOperations.__doc__
+    _already_valid_message = 'after'
+
+    def __init__(
+        self,
+        *nodes,
+        owner_senders: Union[Operation, str] = Operation.KEEP,
+        owner_receivers: Union[Operation, str] = Operation.MERGE,
+        subject_senders: typing_subject_operation = Operation.MERGE,
+        subject_receivers: typing_subject_operation = Operation.KEEP,
+        reconnect_non_subject_receivers: bool = True,
+        remove_new_self_referential_edges: bool = True,
+        prune_cycles: bool = True,
+        ignore_conflicts: bool = False,
+    ):
+        super().__init__(
+            *nodes,
+            owner_senders=owner_senders,
+            owner_receivers=owner_receivers,
+            subject_senders=subject_senders,
+            subject_receivers=subject_receivers,
+            reconnect_non_subject_receivers=reconnect_non_subject_receivers,
+            remove_new_self_referential_edges=remove_new_self_referential_edges,
+            prune_cycles=prune_cycles,
+            ignore_conflicts=ignore_conflicts,
+        )
+
+    def _nodes_already_valid(self, graph):
+        return [n for n in self.nodes if n in graph[self.owner]]
+
+    def _is_required_edge(self, sender, receiver):
+        return sender in self.nodes and receiver is self.owner
+
+    def _process(self, graph):
+        graph = super()._process(graph)
+
+        graph[self.owner] = graph[self.owner].union(self.nodes)
+
+        return graph
+
+
+class AfterNode(AfterNodes, _GSCSingleNode):
+    """
+    Adds a dependency from the specified node to the owner and
+    optionally modifies the senders and receivers of both
+    """
+    __doc__ += _GSCWithOperations.__doc__
+    __doc__ += _GSCSingleNode.__doc__
+    pass
+
+
+class AddEdgeTo(_GSCSingleNode):
+    """
+    Adds an edge from `AddEdgeTo.owner <ConditionBase.owner>` to
+    `AddEdgeTo.node`
+    """
+    __doc__ += _GSCSingleNode.__doc__
+
+    def _process(self, graph):
+        graph[self.node].add(self.owner)
+        return graph
+
+
+class RemoveEdgeFrom(_GSCSingleNode):
+    """
+    Removes an edge from `RemoveEdgeFrom.node` to `RemoveEdgeFrom.owner
+    <ConditionBase.owner>`
+    """
+    __doc__ += _GSCSingleNode.__doc__
+
+    def _process(self, graph):
+        try:
+            graph[self.owner].remove(self.node)
+        except KeyError as e:
+            warnings.warn(
+                f'{self}: there was no edge from {self.node} to {self.owner}: {e}'
+            )
+        return graph

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -143,3 +143,16 @@ def test_output_graph_image(graph, nx_type, format, tmp_path):
 
     gs.output_graph_image(graph, fname, format)
     gs.output_graph_image(nx_graph, fname, format)
+
+
+@pytest.mark.parametrize(
+    'graph, expected_receivers',
+    [
+        (
+            {'A': set(), 'B': {'A'}, 'C': {'A', 'B'}, 'D': {'E'}, 'E': {'D'}, 'F': set()},
+            {'A': {'B', 'C'}, 'B': {'C'}, 'C': set(), 'D': {'E'}, 'E': {'D'}, 'F': set()},
+        ),
+    ]
+)
+def test_get_receivers(graph, expected_receivers):
+    assert gs.get_receivers(graph) == expected_receivers


### PR DESCRIPTION
A GraphStructureCondition is a pseudo-Condition that enables the user to
make defined changes to the scheduler graph using the same interface as
old (basic) Conditions. This allows for the easier definition of some
execution patterns that are difficult to do with basic Conditions by
leveraging the Scheduler's default consideration pattern based on the
graph structure.

A node has exactly one basic Condition, and may additionally have any
number of GraphStructureConditions that are applied in sequence.

Add pandas, scipy requirements (needed for get_simple_cycles)