### PR TITLE
ci: workflow to attempt to prevent auto disabling of workflows

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,18 @@
+name: Enable All Workflows
+
+on:
+  schedule:
+    # arbitrary time weekly
+    # anything less than 60 days should work though
+    - cron: "17 0 * * 2"
+  workflow_dispatch:
+
+jobs:
+  enable_workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run github-keepalive.sh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: bash -x ./bin/github-keepalive.sh

--- a/bin/github-keepalive.sh
+++ b/bin/github-keepalive.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKFLOW_IDS="$(gh api 'repos/{owner}/{repo}/actions/workflows' | jq -r '.workflows[] | .id')"
+while read -r workflow; do
+	gh api -X PUT 'repos/{owner}/{repo}/actions/workflows/'"${workflow}"'/enable'
+done <<<"$WORKFLOW_IDS"


### PR DESCRIPTION
github disables workflows after 60 days without certain activity. explicitly enabling them periodically via the github API seems like it may prevent this.