### PR TITLE
requirements: pin pytest<9.1 due to breaking changes

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 pydot
-pytest
+pytest <9.1
 pytest-cov
 pytest-helpers-namespace
 pytest-pycodestyle


### PR DESCRIPTION
pytest_collect_file hook no longer has 'path' argument